### PR TITLE
Fixed "Uncaught ReferenceError" in Chrome

### DIFF
--- a/ExampleOrientationEvents.framer/app.coffee
+++ b/ExampleOrientationEvents.framer/app.coffee
@@ -22,7 +22,7 @@ module.smoothOrientation = .35
 # Just so it constantly print NaN when in Framer Studio (and not running from mobile device)
 if Utils.isMobile()
 	Utils.interval .1, ->
-		gamma = module.orientation.gamma
+		gamma = module.orientation.gamma if module.orientation.gamma?
 		
 		wallpaper.animate
 			properties:

--- a/ExampleOrientationEvents.framer/modules/OrientationEvents.coffee
+++ b/ExampleOrientationEvents.framer/modules/OrientationEvents.coffee
@@ -71,7 +71,7 @@ _motion = (event) ->
 		rotationRate: event.rotationRate
 		interval: event.interval
 
-	return motion
+	return motion if motion?
 
 _orientation = (event) ->
 	filteredAlpha = (event.alpha * exports.smoothOrientation) + (filteredAlpha * (1- exports.smoothOrientation))
@@ -85,5 +85,5 @@ _orientation = (event) ->
 		absolute: event.absolute
 
 
-	return orientation
+	return orientation if orientation?
 

--- a/OrientationEvents.coffee
+++ b/OrientationEvents.coffee
@@ -71,7 +71,7 @@ _motion = (event) ->
 		rotationRate: event.rotationRate
 		interval: event.interval
 
-	return motion
+	return motion if motion?
 
 _orientation = (event) ->
 	filteredAlpha = (event.alpha * exports.smoothOrientation) + (filteredAlpha * (1- exports.smoothOrientation))
@@ -85,5 +85,5 @@ _orientation = (event) ->
 		absolute: event.absolute
 
 
-	return orientation
+	return orientation if orientation?
 


### PR DESCRIPTION
... and similar errors in Safari.

This PR makes sure the module doesn't return values before they're ready.
